### PR TITLE
Add Classic FPL support with League Standings page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,13 @@
 # --- FPL league basics ---
 FPL_DRAFT_LEAGUE_ID=
 FPL_DRAFT_TEAM_ID=
-FPL_CLASSIC_LEAGUE_ID=
+
+# Classic FPL - comma-separated league IDs with optional names
+# Format: id:name,id:name,... (name is optional, will be fetched from API if omitted)
+# Examples:
+#   FPL_CLASSIC_LEAGUE_IDS=123456:Work League,789012:Friends League
+#   FPL_CLASSIC_LEAGUE_IDS=123456,789012
+FPL_CLASSIC_LEAGUE_IDS=
 FPL_CLASSIC_TEAM_ID=
 
 # --- Notifications ---

--- a/main.py
+++ b/main.py
@@ -16,6 +16,9 @@ from scripts.fpl.player_projections import show_player_projections_page
 from scripts.fpl.projected_lineups import show_projected_lineups
 from scripts.fpl.injuries import show_injuries_page
 
+# --- Classic pages ---
+from scripts.classic.league_standings import show_classic_league_standings_page
+
 # ------------------------------------------------------------
 # Page config (must be first Streamlit command in the script)
 # ------------------------------------------------------------
@@ -169,6 +172,7 @@ def main():
             "Classic Pages",
             [
                 "Home",
+                "League Standings",
                 "Fixture Projections",
                 "Waiver Wire",
                 "Team Analysis",
@@ -178,6 +182,8 @@ def main():
 
         if subpage == "Home":
             render_classic_home()
+        elif subpage == "League Standings":
+            show_classic_league_standings_page()
         elif subpage == "Fixture Projections":
             # Replace with your Classic fixture projections function when ready
             render_placeholder("Classic — Fixture Projections")

--- a/scripts/classic/league_standings.py
+++ b/scripts/classic/league_standings.py
@@ -1,0 +1,272 @@
+import config
+import pandas as pd
+import random
+import streamlit as st
+from scripts.common.utils import (
+    get_classic_league_standings,
+    get_classic_team_history,
+)
+
+
+def get_league_display_options() -> list:
+    """
+    Build list of league options for the dropdown.
+    Returns list of dicts with 'id', 'name', 'display' keys.
+    """
+    leagues = config.FPL_CLASSIC_LEAGUE_IDS or []
+    options = []
+
+    for league in leagues:
+        league_id = league["id"]
+        # Use configured name or fetch from API
+        if league["name"]:
+            name = league["name"]
+        else:
+            # Try to fetch name from API
+            data = get_classic_league_standings(league_id)
+            if data and "league" in data:
+                name = data["league"].get("name", f"League {league_id}")
+            else:
+                name = f"League {league_id}"
+
+        options.append({
+            "id": league_id,
+            "name": name,
+            "display": f"{name} ({league_id})"
+        })
+
+    return options
+
+
+def fetch_standings_data(league_id: int) -> dict:
+    """
+    Fetch league standings and metadata.
+    Returns dict with 'league_info', 'standings', 'scoring_type'.
+    """
+    data = get_classic_league_standings(league_id)
+
+    if not data:
+        return None
+
+    league_info = data.get("league", {})
+    standings_data = data.get("standings", {})
+
+    # Determine scoring type from league info
+    # Classic FPL uses 'league_type': 'x' for classic, 's' for H2H
+    # Also check 'scoring' field if available
+    league_type = league_info.get("league_type", "x")
+    scoring = league_info.get("scoring", "c")  # 'c' = classic, 'h' = h2h
+
+    if league_type == "s" or scoring == "h":
+        scoring_type = "H2H"
+    else:
+        scoring_type = "Classic"
+
+    return {
+        "league_info": league_info,
+        "standings": standings_data,
+        "scoring_type": scoring_type
+    }
+
+
+def format_classic_standings(standings_data: dict) -> pd.DataFrame:
+    """
+    Format classic (total points) league standings.
+    """
+    results = standings_data.get("results", [])
+
+    if not results:
+        return pd.DataFrame()
+
+    rows = []
+    for entry in results:
+        rows.append({
+            "Rank": entry.get("rank", "-"),
+            "Team": entry.get("entry_name", "Unknown"),
+            "Manager": entry.get("player_name", "Unknown"),
+            "GW Pts": entry.get("event_total", 0),
+            "Total Pts": entry.get("total", 0),
+        })
+
+    df = pd.DataFrame(rows)
+    return df
+
+
+def format_h2h_standings(standings_data: dict) -> pd.DataFrame:
+    """
+    Format H2H league standings.
+    """
+    results = standings_data.get("results", [])
+
+    if not results:
+        return pd.DataFrame()
+
+    rows = []
+    for entry in results:
+        rows.append({
+            "Rank": entry.get("rank", "-"),
+            "Team": entry.get("entry_name", "Unknown"),
+            "Manager": entry.get("player_name", "Unknown"),
+            "W": entry.get("matches_won", 0),
+            "D": entry.get("matches_drawn", 0),
+            "L": entry.get("matches_lost", 0),
+            "PF": entry.get("points_for", 0),
+            "PA": entry.get("points_against", 0),
+            "Pts": entry.get("total", 0),
+        })
+
+    df = pd.DataFrame(rows)
+    return df
+
+
+def highlight_my_team(df: pd.DataFrame, team_id: int) -> pd.DataFrame:
+    """
+    Return a styled DataFrame with the user's team highlighted.
+    """
+    # Get team history to find the team name
+    history = get_classic_team_history(team_id)
+    my_team_name = None
+
+    if history:
+        # The entry name might be in the team history somewhere
+        # We need to fetch entry details for the team name
+        from scripts.common.utils import get_entry_details
+        entry = get_entry_details(team_id)
+        if entry:
+            my_team_name = entry.get("name")
+
+    def highlight_row(row):
+        if my_team_name and row.get("Team") == my_team_name:
+            return ["background-color: #e6f3ff"] * len(row)
+        return [""] * len(row)
+
+    return df.style.apply(highlight_row, axis=1)
+
+
+def show_classic_league_standings_page():
+    """
+    Display Classic FPL league standings with league selector.
+    """
+    st.title("Classic League Standings")
+
+    # Get configured leagues
+    league_options = get_league_display_options()
+
+    if not league_options:
+        st.warning("No Classic leagues configured. Add leagues to FPL_CLASSIC_LEAGUE_IDS in your .env file.")
+        st.code("FPL_CLASSIC_LEAGUE_IDS=123456:My League,789012:Friends League")
+        return
+
+    # Initialize random league selection on first load
+    if "classic_league_index" not in st.session_state:
+        st.session_state.classic_league_index = random.randint(0, len(league_options) - 1)
+
+    # League selector
+    display_options = [opt["display"] for opt in league_options]
+    selected_display = st.selectbox(
+        "Select League",
+        options=display_options,
+        index=st.session_state.classic_league_index,
+        key="classic_league_selector"
+    )
+
+    # Update session state when user changes selection
+    new_index = display_options.index(selected_display)
+    if new_index != st.session_state.classic_league_index:
+        st.session_state.classic_league_index = new_index
+
+    # Get selected league ID
+    selected_league = league_options[st.session_state.classic_league_index]
+    league_id = selected_league["id"]
+
+    # Fetch standings
+    with st.spinner("Loading standings..."):
+        data = fetch_standings_data(league_id)
+
+    if not data:
+        st.error(f"Failed to load standings for league {league_id}. Please check the league ID.")
+        return
+
+    # Display league info
+    league_info = data["league_info"]
+    scoring_type = data["scoring_type"]
+
+    col1, col2, col3 = st.columns(3)
+    with col1:
+        st.metric("League", league_info.get("name", "Unknown"))
+    with col2:
+        st.metric("Format", scoring_type)
+    with col3:
+        st.metric("Created", league_info.get("created", "Unknown")[:10] if league_info.get("created") else "Unknown")
+
+    st.divider()
+
+    # Format and display standings based on type
+    standings = data["standings"]
+
+    if scoring_type == "H2H":
+        st.subheader("Head-to-Head Standings")
+        df = format_h2h_standings(standings)
+
+        if df.empty:
+            st.info("No standings data available yet.")
+        else:
+            # Style the dataframe
+            st.dataframe(
+                df,
+                use_container_width=True,
+                hide_index=True,
+                column_config={
+                    "Rank": st.column_config.NumberColumn("Rank", width="small"),
+                    "Team": st.column_config.TextColumn("Team", width="medium"),
+                    "Manager": st.column_config.TextColumn("Manager", width="medium"),
+                    "W": st.column_config.NumberColumn("W", width="small"),
+                    "D": st.column_config.NumberColumn("D", width="small"),
+                    "L": st.column_config.NumberColumn("L", width="small"),
+                    "PF": st.column_config.NumberColumn("Points For", width="small"),
+                    "PA": st.column_config.NumberColumn("Points Against", width="small"),
+                    "Pts": st.column_config.NumberColumn("League Pts", width="small"),
+                }
+            )
+    else:
+        st.subheader("Overall Standings")
+        df = format_classic_standings(standings)
+
+        if df.empty:
+            st.info("No standings data available yet.")
+        else:
+            st.dataframe(
+                df,
+                use_container_width=True,
+                hide_index=True,
+                column_config={
+                    "Rank": st.column_config.NumberColumn("Rank", width="small"),
+                    "Team": st.column_config.TextColumn("Team", width="medium"),
+                    "Manager": st.column_config.TextColumn("Manager", width="medium"),
+                    "GW Pts": st.column_config.NumberColumn("GW Points", width="small"),
+                    "Total Pts": st.column_config.NumberColumn("Total Points", width="small"),
+                }
+            )
+
+    # Show pagination info if available
+    has_next = standings.get("has_next", False)
+    if has_next:
+        st.caption("Showing first page of standings. Large leagues have additional pages.")
+
+    # Show my team's position if configured
+    if config.FPL_CLASSIC_TEAM_ID:
+        st.divider()
+        with st.expander("My Team Info"):
+            history = get_classic_team_history(config.FPL_CLASSIC_TEAM_ID)
+            if history and history.get("current"):
+                latest_gw = history["current"][-1] if history["current"] else {}
+
+                col1, col2, col3, col4 = st.columns(4)
+                with col1:
+                    st.metric("Overall Rank", f"{latest_gw.get('overall_rank', 'N/A'):,}" if latest_gw.get('overall_rank') else "N/A")
+                with col2:
+                    st.metric("GW Rank", f"{latest_gw.get('rank', 'N/A'):,}" if latest_gw.get('rank') else "N/A")
+                with col3:
+                    st.metric("GW Points", latest_gw.get("points", "N/A"))
+                with col4:
+                    st.metric("Total Points", latest_gw.get("total_points", "N/A"))


### PR DESCRIPTION
  ## Summary                                                                                               
                                                                                                           
  - Add 5 Classic FPL API functions (`get_classic_bootstrap_static`, `get_classic_team_picks`,             
  `get_classic_team_history`, `get_classic_league_standings`, `get_classic_transfers`)                     
  - Support multiple Classic leagues via `FPL_CLASSIC_LEAGUE_IDS` env var (format: `id:name,id:name,...`)  
  - Add Classic League Standings page with league toggle dropdown                                          
  - Auto-detect H2H vs Classic points format and display appropriate columns                               
  - Reorganize codebase into logical subdirectories (`scripts/draft/`, `scripts/classic/`, `scripts/fpl/`, 
  `scripts/common/`)   