### PR TITLE
Add Classic FPL Team Analysis page with season trends

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ from scripts.fpl.injuries import show_injuries_page
 
 # --- Classic pages ---
 from scripts.classic.league_standings import show_classic_league_standings_page
+from scripts.classic.team_analysis import show_classic_team_analysis_page
 
 # ------------------------------------------------------------
 # Page config (must be first Streamlit command in the script)
@@ -191,8 +192,7 @@ def main():
             # Replace with your Classic waiver/free transfers helper when ready
             render_placeholder("Classic — Waiver/Transfers")
         elif subpage == "Team Analysis":
-            # Replace with your Classic team analysis when ready
-            render_placeholder("Classic — Team Analysis")
+            show_classic_team_analysis_page()
         elif subpage == "League Analysis":
             # Replace with your Classic league analysis when ready
             render_placeholder("Classic — League Analysis")

--- a/scripts/classic/league_standings.py
+++ b/scripts/classic/league_standings.py
@@ -3,7 +3,7 @@ import pandas as pd
 import random
 import streamlit as st
 from scripts.common.utils import (
-    get_classic_league_standings,
+    get_league_standings,
     get_classic_team_history,
 )
 
@@ -22,8 +22,8 @@ def get_league_display_options() -> list:
         if league["name"]:
             name = league["name"]
         else:
-            # Try to fetch name from API
-            data = get_classic_league_standings(league_id)
+            # Try to fetch name from API (works for both Classic and H2H)
+            data = get_league_standings(league_id)
             if data and "league" in data:
                 name = data["league"].get("name", f"League {league_id}")
             else:
@@ -43,7 +43,7 @@ def fetch_standings_data(league_id: int) -> dict:
     Fetch league standings and metadata.
     Returns dict with 'league_info', 'standings', 'scoring_type'.
     """
-    data = get_classic_league_standings(league_id)
+    data = get_league_standings(league_id)
 
     if not data:
         return None
@@ -191,13 +191,15 @@ def show_classic_league_standings_page():
     league_info = data["league_info"]
     scoring_type = data["scoring_type"]
 
-    col1, col2, col3 = st.columns(3)
+    col1, col2, col3 = st.columns([3, 1, 1])
     with col1:
-        st.metric("League", league_info.get("name", "Unknown"))
+        league_name = league_info.get("name", "Unknown")
+        st.markdown(f"### {league_name}")
     with col2:
         st.metric("Format", scoring_type)
     with col3:
-        st.metric("Created", league_info.get("created", "Unknown")[:10] if league_info.get("created") else "Unknown")
+        created = league_info.get("created", "")[:10] if league_info.get("created") else "Unknown"
+        st.metric("Created", created)
 
     st.divider()
 

--- a/scripts/classic/team_analysis.py
+++ b/scripts/classic/team_analysis.py
@@ -1,0 +1,563 @@
+"""
+Classic FPL - My Team Analysis Page
+
+Displays the user's current squad with projected points, captain picks,
+squad value, and gameweek history.
+"""
+
+import config
+import pandas as pd
+import streamlit as st
+from scripts.common.utils import (
+    get_classic_bootstrap_static,
+    get_classic_team_picks,
+    get_classic_team_history,
+    get_entry_details,
+    get_current_gameweek,
+    get_rotowire_player_projections,
+    position_converter,
+)
+from fuzzywuzzy import fuzz
+
+
+def _format_money(value: int) -> str:
+    """Format FPL money value (stored as tenths) to display format."""
+    if value is None:
+        return "N/A"
+    return f"£{value / 10:.1f}m"
+
+
+def _get_chip_display(active_chip: str) -> str:
+    """Format chip name for display."""
+    chip_names = {
+        "wildcard": "Wildcard",
+        "freehit": "Free Hit",
+        "bboost": "Bench Boost",
+        "3xc": "Triple Captain",
+    }
+    if not active_chip:
+        return "None"
+    return chip_names.get(active_chip, active_chip.title())
+
+
+def _format_rank_change(current: int, previous: int) -> str:
+    """Format rank change with arrow indicator."""
+    if current is None or previous is None:
+        return ""
+    diff = previous - current  # Positive = improved (lower rank is better)
+    if diff > 0:
+        return f"↑ {diff:,}"
+    elif diff < 0:
+        return f"↓ {abs(diff):,}"
+    return "→ 0"
+
+
+def _build_squad_dataframe(picks: list, bootstrap: dict) -> pd.DataFrame:
+    """Map element IDs from picks to player info from bootstrap data."""
+    elements = {p["id"]: p for p in bootstrap.get("elements", [])}
+    teams = {t["id"]: t["short_name"] for t in bootstrap.get("teams", [])}
+
+    rows = []
+    for pick in picks:
+        element_id = pick["element"]
+        player = elements.get(element_id, {})
+
+        rows.append({
+            "element_id": element_id,
+            "Player": player.get("web_name", "Unknown"),
+            "Full Name": f"{player.get('first_name', '')} {player.get('second_name', '')}".strip(),
+            "Team": teams.get(player.get("team"), "???"),
+            "Position": position_converter(player.get("element_type")),
+            "squad_position": pick["position"],
+            "is_captain": pick.get("is_captain", False),
+            "is_vice_captain": pick.get("is_vice_captain", False),
+            "multiplier": pick.get("multiplier", 1),
+        })
+
+    return pd.DataFrame(rows)
+
+
+def _lookup_projection(player_name: str, team: str, position: str, projections_df: pd.DataFrame) -> dict:
+    """Look up projection for a player using fuzzy matching."""
+    if projections_df is None or projections_df.empty:
+        return {"Points": None, "Pos Rank": None}
+
+    best_match = None
+    best_score = 0
+
+    for _, row in projections_df.iterrows():
+        proj_name = str(row.get("Player", ""))
+        proj_team = str(row.get("Team", ""))
+        proj_pos = str(row.get("Position", ""))
+
+        # Calculate name similarity
+        score = fuzz.ratio(player_name.lower(), proj_name.lower())
+
+        # Boost score if team and position match
+        if proj_team == team and proj_pos == position:
+            score += 15
+
+        if score > best_score and score >= 60:
+            best_score = score
+            best_match = row
+
+    if best_match is not None:
+        return {
+            "Points": best_match.get("Points"),
+            "Pos Rank": best_match.get("Pos Rank", "N/A"),
+        }
+
+    return {"Points": None, "Pos Rank": None}
+
+
+def _add_projections_to_squad(squad_df: pd.DataFrame, projections_df: pd.DataFrame) -> pd.DataFrame:
+    """Add Rotowire projections to squad dataframe."""
+    points_list = []
+    rank_list = []
+
+    for _, row in squad_df.iterrows():
+        proj = _lookup_projection(
+            row["Player"],
+            row["Team"],
+            row["Position"],
+            projections_df
+        )
+        points_list.append(proj["Points"])
+        rank_list.append(proj["Pos Rank"])
+
+    squad_df["Points"] = points_list
+    squad_df["Pos Rank"] = rank_list
+    return squad_df
+
+
+def _get_sub_priority_label(position: int) -> str:
+    """Get display label for bench position."""
+    labels = {12: "GK Sub", 13: "1st Sub", 14: "2nd Sub", 15: "3rd Sub"}
+    return labels.get(position, "")
+
+
+def _style_rank_change(val):
+    """Style rank change values with colors."""
+    if isinstance(val, str):
+        if val.startswith("↑"):
+            return "color: #00c853; font-weight: bold;"
+        elif val.startswith("↓"):
+            return "color: #ff5252; font-weight: bold;"
+    return ""
+
+
+def show_classic_team_analysis_page():
+    """Display Classic FPL My Team page with squad, projections, and metrics."""
+
+    # Custom CSS for better styling
+    st.markdown("""
+    <style>
+    .team-header {
+        background: linear-gradient(135deg, #37003c 0%, #00ff87 100%);
+        padding: 20px;
+        border-radius: 10px;
+        margin-bottom: 20px;
+    }
+    .metric-card {
+        background-color: #f8f9fa;
+        border-radius: 8px;
+        padding: 15px;
+        text-align: center;
+        border-left: 4px solid #37003c;
+    }
+    .starting-xi-header {
+        background-color: #37003c;
+        color: white;
+        padding: 10px 15px;
+        border-radius: 8px 8px 0 0;
+        margin-top: 20px;
+    }
+    .bench-header {
+        background-color: #6c757d;
+        color: white;
+        padding: 10px 15px;
+        border-radius: 8px 8px 0 0;
+        margin-top: 20px;
+    }
+    .captain-badge {
+        background-color: #ffd700;
+        color: #000;
+        padding: 2px 6px;
+        border-radius: 4px;
+        font-weight: bold;
+        font-size: 0.8em;
+    }
+    .vice-captain-badge {
+        background-color: #c0c0c0;
+        color: #000;
+        padding: 2px 6px;
+        border-radius: 4px;
+        font-weight: bold;
+        font-size: 0.8em;
+    }
+    .trend-up { color: #00c853; font-weight: bold; }
+    .trend-down { color: #ff5252; font-weight: bold; }
+    .trend-neutral { color: #757575; }
+    </style>
+    """, unsafe_allow_html=True)
+
+    st.title("My Classic FPL Team")
+
+    # Check if team ID is configured
+    team_id = config.FPL_CLASSIC_TEAM_ID
+    if not team_id:
+        st.warning("No Classic FPL team configured.")
+        st.info(
+            "Add your team ID to your `.env` file:\n\n"
+            "```\nFPL_CLASSIC_TEAM_ID=123456\n```\n\n"
+            "You can find your team ID in the URL when viewing your team on the FPL website."
+        )
+        return
+
+    # Fetch entry details for header
+    with st.spinner("Loading team data..."):
+        entry = get_entry_details(team_id)
+
+    if not entry:
+        st.error(f"Failed to load team details for team ID {team_id}. Please check your configuration.")
+        return
+
+    # Team Header Section
+    st.markdown("---")
+    team_name = entry.get("name", "Unknown Team")
+    manager_first = entry.get("player_first_name", "")
+    manager_last = entry.get("player_last_name", "")
+    manager_name = f"{manager_first} {manager_last}".strip() or "Unknown Manager"
+
+    col1, col2 = st.columns([2, 1])
+    with col1:
+        st.markdown(f"### {team_name}")
+        st.markdown(f"**Manager:** {manager_name}")
+    with col2:
+        overall_rank = entry.get("summary_overall_rank")
+        total_points = entry.get("summary_overall_points")
+        if overall_rank:
+            st.metric("Overall Rank", f"{overall_rank:,}")
+        if total_points:
+            st.metric("Total Points", f"{total_points:,}")
+
+    st.markdown("---")
+
+    # Get current gameweek and history
+    current_gw = get_current_gameweek()
+    history = get_classic_team_history(team_id)
+
+    if not history or not history.get("current"):
+        st.warning("No gameweek history available yet.")
+        return
+
+    gw_history = history["current"]
+    available_gws = [gw["event"] for gw in gw_history]
+
+    if not available_gws:
+        st.warning("No gameweek data available yet.")
+        return
+
+    # Gameweek Selector and Chip Display
+    col_gw, col_chip, col_spacer = st.columns([1, 1, 2])
+    with col_gw:
+        selected_gw = st.selectbox(
+            "Select Gameweek",
+            options=sorted(available_gws, reverse=True),
+            index=0,
+            format_func=lambda x: f"GW {x}",
+        )
+
+    # Fetch picks for selected gameweek
+    picks_data = get_classic_team_picks(team_id, selected_gw)
+    if not picks_data:
+        st.error(f"Failed to load squad for Gameweek {selected_gw}.")
+        return
+
+    picks = picks_data.get("picks", [])
+    active_chip = picks_data.get("active_chip")
+    entry_history = picks_data.get("entry_history", {})
+
+    with col_chip:
+        chip_display = _get_chip_display(active_chip)
+        if active_chip:
+            st.success(f"**Chip:** {chip_display}")
+        else:
+            st.info("**Chip:** None")
+
+    # GW Metrics in styled cards
+    st.markdown("#### Gameweek Performance")
+    col1, col2, col3, col4 = st.columns(4)
+
+    with col1:
+        gw_points = entry_history.get("points", "N/A")
+        st.metric("GW Points", gw_points)
+
+    with col2:
+        gw_rank = entry_history.get("rank")
+        st.metric("GW Rank", f"{gw_rank:,}" if gw_rank else "N/A")
+
+    with col3:
+        squad_value = entry_history.get("value")
+        st.metric("Squad Value", _format_money(squad_value))
+
+    with col4:
+        bank = entry_history.get("bank")
+        st.metric("Bank", _format_money(bank))
+
+    st.markdown("---")
+
+    # Historical Trends Section
+    if len(gw_history) > 1:
+        with st.expander("Season Trends", expanded=True):
+            # Get gameweek averages from bootstrap data
+            bootstrap = get_classic_bootstrap_static()
+            gw_averages = {}
+            if bootstrap and "events" in bootstrap:
+                for event in bootstrap["events"]:
+                    gw_num = event.get("id")
+                    avg_score = event.get("average_entry_score")
+                    if gw_num and avg_score:
+                        gw_averages[gw_num] = avg_score
+
+            # Create trend dataframe
+            trend_data = []
+            cumulative_avg = 0
+            for i, gw in enumerate(gw_history):
+                gw_num = gw["event"]
+                gw_avg = gw_averages.get(gw_num, 0)
+                cumulative_avg += gw_avg
+                trend_data.append({
+                    "GW": gw_num,
+                    "Your Points": gw["points"],
+                    "Average Points": gw_avg,
+                    "Your Total": gw["total_points"],
+                    "Average Total": cumulative_avg,
+                    "GW Rank": gw.get("rank"),
+                    "Overall Rank": gw.get("overall_rank"),
+                    "Value": gw.get("value", 0) / 10,
+                    "Bank": gw.get("bank", 0) / 10,
+                    "Transfers": gw.get("event_transfers", 0),
+                    "Hits": gw.get("event_transfers_cost", 0),
+                })
+
+            trend_df = pd.DataFrame(trend_data)
+
+            # Display charts
+            tab1, tab2, tab3, tab4 = st.tabs(["GW Points", "Total Points", "Rank", "Value"])
+
+            with tab1:
+                st.markdown("**Gameweek Points vs Average**")
+                points_df = trend_df.set_index("GW")[["Your Points", "Average Points"]].copy()
+                st.line_chart(points_df)
+
+                # Show points above/below average
+                trend_df["vs Avg"] = trend_df["Your Points"] - trend_df["Average Points"]
+                total_vs_avg = trend_df["vs Avg"].sum()
+                if total_vs_avg > 0:
+                    st.success(f"**+{total_vs_avg:.0f}** points above average this season")
+                elif total_vs_avg < 0:
+                    st.error(f"**{total_vs_avg:.0f}** points below average this season")
+                else:
+                    st.info("Exactly average this season")
+
+            with tab2:
+                st.markdown("**Cumulative Total Points vs Average**")
+                total_df = trend_df.set_index("GW")[["Your Total", "Average Total"]].copy()
+                st.line_chart(total_df)
+
+                # Show current difference
+                latest = trend_df.iloc[-1]
+                diff = latest["Your Total"] - latest["Average Total"]
+                if diff > 0:
+                    st.success(f"**+{diff:.0f}** points ahead of average manager")
+                elif diff < 0:
+                    st.error(f"**{abs(diff):.0f}** points behind average manager")
+
+            with tab3:
+                st.markdown("**Overall Rank Progression**")
+                rank_df = trend_df.set_index("GW")[["Overall Rank"]].copy()
+                st.line_chart(rank_df)
+                st.caption("Lower rank = better position")
+
+            with tab4:
+                st.markdown("**Squad Value & Bank**")
+                value_df = trend_df.set_index("GW")[["Value", "Bank"]].copy()
+                st.line_chart(value_df)
+
+            # Summary stats
+            st.markdown("#### Season Summary")
+            sum_col1, sum_col2, sum_col3, sum_col4 = st.columns(4)
+
+            with sum_col1:
+                try:
+                    points_col = pd.to_numeric(trend_df["Your Points"], errors="coerce")
+                    if points_col.notna().any():
+                        best_idx = points_col.idxmax()
+                        best_gw = trend_df.loc[best_idx]
+                        st.metric("Best GW", f"GW{int(best_gw['GW'])} ({int(best_gw['Your Points'])} pts)")
+                    else:
+                        st.metric("Best GW", "N/A")
+                except Exception:
+                    st.metric("Best GW", "N/A")
+
+            with sum_col2:
+                total_transfers = trend_df["Transfers"].sum()
+                st.metric("Total Transfers", int(total_transfers))
+
+            with sum_col3:
+                total_hits = trend_df["Hits"].sum()
+                st.metric("Total Hits", f"-{int(total_hits)} pts")
+
+            with sum_col4:
+                if len(trend_df) >= 2:
+                    start_rank = trend_df.iloc[0]["Overall Rank"]
+                    end_rank = trend_df.iloc[-1]["Overall Rank"]
+                    if start_rank and end_rank:
+                        rank_change = int(start_rank - end_rank)
+                        if rank_change > 0:
+                            st.metric("Rank Change", f"↑ {rank_change:,}", delta=f"{rank_change:,}")
+                        elif rank_change < 0:
+                            st.metric("Rank Change", f"↓ {abs(rank_change):,}", delta=f"{rank_change:,}")
+                        else:
+                            st.metric("Rank Change", "→ 0")
+
+    st.markdown("---")
+
+    # Fetch bootstrap data for player info
+    bootstrap = get_classic_bootstrap_static()
+    if not bootstrap:
+        st.error("Failed to load player data. Please try again later.")
+        return
+
+    # Build squad dataframe
+    squad_df = _build_squad_dataframe(picks, bootstrap)
+
+    # Try to fetch and merge projections
+    projections_available = False
+    projections_df = None
+    try:
+        rotowire_url = config.ROTOWIRE_URL
+        if rotowire_url:
+            with st.spinner("Loading projections..."):
+                projections_df = get_rotowire_player_projections(rotowire_url)
+            if projections_df is not None and not projections_df.empty:
+                squad_df = _add_projections_to_squad(squad_df, projections_df)
+                projections_available = True
+    except Exception as e:
+        st.warning(f"Could not load projections: {str(e)}")
+
+    if not projections_available:
+        st.info("Rotowire projections unavailable. Displaying squad without projected points.")
+        squad_df["Points"] = None
+        squad_df["Pos Rank"] = None
+
+    # Split into starting XI and bench
+    starting_xi = squad_df[squad_df["squad_position"] <= 11].copy()
+    bench = squad_df[squad_df["squad_position"] > 11].copy()
+
+    # Format player names with captain indicators
+    def format_player_name(row):
+        name = row["Player"]
+        if row["is_captain"]:
+            return f"{name} (C)"
+        elif row["is_vice_captain"]:
+            return f"{name} (V)"
+        return name
+
+    starting_xi["Display Name"] = starting_xi.apply(format_player_name, axis=1)
+    bench["Display Name"] = bench.apply(format_player_name, axis=1)
+    bench["Priority"] = bench["squad_position"].apply(_get_sub_priority_label)
+
+    # Calculate totals
+    if projections_available:
+        starting_proj_total = pd.to_numeric(starting_xi["Points"], errors="coerce").sum()
+        bench_proj_total = pd.to_numeric(bench["Points"], errors="coerce").sum()
+    else:
+        starting_proj_total = None
+        bench_proj_total = None
+
+    # Starting XI Section
+    st.markdown("### Starting XI")
+    if projections_available and starting_proj_total and pd.notna(starting_proj_total):
+        st.markdown(f"**Total Projected Points: {starting_proj_total:.1f}**")
+
+    # Prepare display columns
+    starting_display = starting_xi[["Display Name", "Team", "Position"]].copy()
+    if projections_available:
+        starting_display["Proj Pts"] = starting_xi["Points"]
+        starting_display["Pos Rank"] = starting_xi["Pos Rank"]
+
+    starting_display = starting_display.rename(columns={"Display Name": "Player"})
+
+    # Style the dataframe
+    st.dataframe(
+        starting_display,
+        use_container_width=True,
+        hide_index=True,
+        column_config={
+            "Player": st.column_config.TextColumn("Player", width="large"),
+            "Team": st.column_config.TextColumn("Team", width="small"),
+            "Position": st.column_config.TextColumn("Pos", width="small"),
+            "Proj Pts": st.column_config.NumberColumn("Proj", format="%.1f", width="small"),
+            "Pos Rank": st.column_config.TextColumn("Rank", width="small"),
+        },
+    )
+
+    st.markdown("---")
+
+    # Bench Section
+    st.markdown("### Bench")
+    if projections_available and bench_proj_total and pd.notna(bench_proj_total):
+        st.markdown(f"**Total Projected Points: {bench_proj_total:.1f}**")
+
+    bench_display = bench[["Display Name", "Team", "Position", "Priority"]].copy()
+    if projections_available:
+        bench_display["Proj Pts"] = bench["Points"]
+
+    bench_display = bench_display.rename(columns={"Display Name": "Player"})
+
+    st.dataframe(
+        bench_display,
+        use_container_width=True,
+        hide_index=True,
+        column_config={
+            "Player": st.column_config.TextColumn("Player", width="large"),
+            "Team": st.column_config.TextColumn("Team", width="small"),
+            "Position": st.column_config.TextColumn("Pos", width="small"),
+            "Proj Pts": st.column_config.NumberColumn("Proj", format="%.1f", width="small"),
+            "Priority": st.column_config.TextColumn("Sub Order", width="small"),
+        },
+    )
+
+    st.markdown("---")
+
+    # Chips Used Section
+    with st.expander("Chips Used This Season"):
+        chips = history.get("chips", [])
+        if chips:
+            chip_cols = st.columns(len(chips)) if len(chips) <= 4 else st.columns(4)
+            for i, chip in enumerate(chips):
+                with chip_cols[i % len(chip_cols)]:
+                    chip_name = _get_chip_display(chip.get("name", ""))
+                    chip_gw = chip.get("event", "?")
+                    st.success(f"**{chip_name}**\nGW {chip_gw}")
+        else:
+            st.info("No chips used yet this season.")
+
+    # Past Seasons Section
+    past_seasons = history.get("past", [])
+    if past_seasons:
+        with st.expander("Past Seasons"):
+            past_df = pd.DataFrame(past_seasons)
+            past_df = past_df.rename(columns={
+                "season_name": "Season",
+                "total_points": "Points",
+                "rank": "Rank"
+            })
+            past_df["Rank"] = past_df["Rank"].apply(lambda x: f"{x:,}" if x else "N/A")
+            st.dataframe(
+                past_df[["Season", "Points", "Rank"]],
+                use_container_width=True,
+                hide_index=True,
+            )

--- a/scripts/common/utils.py
+++ b/scripts/common/utils.py
@@ -930,6 +930,59 @@ def get_classic_league_standings(league_id: int, page: int = 1) -> Optional[Dict
 
 
 @st.cache_data(show_spinner=False, ttl=300)
+def get_h2h_league_standings(league_id: int, page: int = 1) -> Optional[Dict[str, Any]]:
+    """
+    Fetch Head-to-Head (H2H) FPL league standings with pagination.
+
+    Returns league metadata and standings for the specified page.
+
+    Endpoint: https://fantasy.premierleague.com/api/leagues-h2h/{league_id}/standings/?page_standings={page}
+
+    Parameters:
+    - league_id: The H2H FPL league ID.
+    - page: Page number for pagination (default: 1).
+
+    Returns:
+    - Dictionary with 'league' (metadata) and 'standings' (results).
+    - None if the request fails or league not found.
+    """
+    if not league_id:
+        return None
+    try:
+        url = f"https://fantasy.premierleague.com/api/leagues-h2h/{league_id}/standings/"
+        params = {"page_standings": page}
+        resp = requests.get(url, params=params, timeout=30)
+        resp.raise_for_status()
+        return resp.json()
+    except Exception:
+        return None
+
+
+def get_league_standings(league_id: int, page: int = 1) -> Optional[Dict[str, Any]]:
+    """
+    Fetch league standings, automatically detecting if it's Classic or H2H.
+
+    Tries the classic endpoint first, then falls back to H2H if that fails.
+
+    Parameters:
+    - league_id: The FPL league ID.
+    - page: Page number for pagination (default: 1).
+
+    Returns:
+    - Dictionary with 'league' (metadata) and 'standings' (results).
+    - None if both endpoints fail.
+    """
+    # Try classic endpoint first
+    data = get_classic_league_standings(league_id, page)
+    if data:
+        return data
+
+    # Fall back to H2H endpoint
+    data = get_h2h_league_standings(league_id, page)
+    return data
+
+
+@st.cache_data(show_spinner=False, ttl=300)
 def get_classic_team_history(team_id: int) -> Optional[Dict[str, Any]]:
     """
     Fetch a Classic FPL team's full season history.


### PR DESCRIPTION
- Create scripts/classic/team_analysis.py with My Team page featuring:
  - Squad display with Starting XI and Bench sections
  - Rotowire projections integration with fuzzy player matching
  - Season trends charts (GW points, total points, rank, value)
  - Comparison against gameweek averages
  - Historical chips usage and past seasons display
- Add H2H league support to fix Starboys league loading issue:
  - New get_h2h_league_standings() function in utils.py
  - New get_league_standings() that auto-detects Classic vs H2H
- Update league_standings.py to use unified league fetcher
- Improve League Standings layout (wider league name column)
- Wire up Team Analysis page in main.py